### PR TITLE
FPO-132: Adds permissions to hub backend to access CustomerApiKeys

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,6 +27,7 @@ Terraform to deploy the service into AWS.
 |------|------|
 | [aws_iam_policy.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_dynamodb_table.customer_api_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/dynamodb_table) | data source |
 | [aws_iam_policy_document.exec](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.secretsmanager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -28,3 +28,7 @@ data "aws_kms_key" "secretsmanager_key" {
 data "aws_ssm_parameter" "ecr_url" {
   name = "/${var.environment}/FPO_DEVELOPER_HUB_BACKEND_ECR_URL"
 }
+
+data "aws_dynamodb_table" "customer_api_keys" {
+  name = "CustomerApiKeys"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -35,6 +35,22 @@ data "aws_iam_policy_document" "task" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:UpdateItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.customer_api_keys.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "task" {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/FPO-132

### What?

I have added/removed/altered:

- [x] Added permissions to update the new table we created for storing FPO keys
- [x] Added data reference to the CusotmerApiKeys

### Why?

I am doing this because:

- This is required for us to add the api controllers for managing customers and their keys
