### PR TITLE
BAU: Renames customer-id to fpo-id to avoid collission of meaning

### DIFF
--- a/spec/models/customerApiKeySpec.ts
+++ b/spec/models/customerApiKeySpec.ts
@@ -18,7 +18,7 @@ describe('CustomerApiKey Model', () => {
       apiKey.Secret = 'some-secret'
       apiKey.Enabled = true
       apiKey.Description = 'some-description'
-      apiKey.CustomerId = 'some-customer-id'
+      apiKey.FpoId = 'some-fpo-id'
       apiKey.CreatedAt = new Date().toISOString()
       apiKey.UpdatedAt = new Date().toISOString()
 
@@ -76,10 +76,10 @@ describe('CustomerApiKey Model', () => {
     })
   })
 
-  describe('when the CustomerId is invalid', () => {
+  describe('when the FpoId is invalid', () => {
     it('is invalid', async () => {
       const apiKey: CustomerApiKey = new CustomerApiKey()
-      apiKey.CustomerId = null as unknown as string
+      apiKey.FpoId = null as unknown as string
 
       const errors = await validate(apiKey)
       expect(errors.length).toBe(1)
@@ -123,7 +123,7 @@ describe('CustomerApiKey Model', () => {
         Secret: 'secret',
         Enabled: true,
         Description: '',
-        CustomerId: 'yodel',
+        FpoId: 'yodel',
         CreatedAt: new Date().toISOString(),
         UpdatedAt: new Date().toISOString(),
         Saved: false
@@ -148,7 +148,7 @@ describe('CustomerApiKey Model', () => {
         Secret: 'secret',
         Enabled: true,
         Description: '',
-        CustomerId: '',
+        FpoId: '',
         CreatedAt: apiKey.CreatedAt,
         UpdatedAt: apiKey.UpdatedAt,
         Saved: false

--- a/spec/repositories/customerApiKeyRepositorySpec.ts
+++ b/spec/repositories/customerApiKeyRepositorySpec.ts
@@ -19,7 +19,7 @@ describe('CustomerApiKeyRepository', () => {
           Secret: 'secret',
           Enabled: true,
           Description: 'description',
-          CustomerId: 'customer-id',
+          FpoId: 'fpo-id',
           CreatedAt: new Date().toISOString(),
           UpdatedAt: new Date().toISOString()
         }

--- a/spec/services/listCustomerApiKeysServiceSpec.ts
+++ b/spec/services/listCustomerApiKeysServiceSpec.ts
@@ -18,7 +18,7 @@ describe('ListCustomerApiKeysService', () => {
           Secret: 'secret',
           Enabled: true,
           Description: 'description',
-          CustomerId: 'customer-id',
+          FpoId: 'fpo-id',
           CreatedAt: new Date().toISOString(),
           UpdatedAt: new Date().toISOString()
         }

--- a/src/models/customerApiKey.ts
+++ b/src/models/customerApiKey.ts
@@ -15,7 +15,7 @@ export class CustomerApiKey {
     Description: string
 
   @IsString()
-    CustomerId: string
+    FpoId: string
 
   @IsDateString()
     CreatedAt: string
@@ -30,7 +30,7 @@ export class CustomerApiKey {
     this.Secret = ''
     this.Enabled = false
     this.Description = ''
-    this.CustomerId = ''
+    this.FpoId = ''
     this.CreatedAt = new Date().toISOString()
     this.UpdatedAt = new Date().toISOString()
     this.Saved = false

--- a/src/services/createCustomerApiKeyService.ts
+++ b/src/services/createCustomerApiKeyService.ts
@@ -17,7 +17,7 @@ class CreateCustomerApiKeyService {
     const customerApiKey = new CustomerApiKey()
     let saved = false
 
-    customerApiKey.CustomerId = customerId
+    customerApiKey.FpoId = customerId
     customerApiKey.CustomerApiKeyId = this.generateClientId()
     customerApiKey.Secret = await this.generateRandomSecret()
     customerApiKey.Enabled = true

--- a/src/services/listCustomerApiKeysService.ts
+++ b/src/services/listCustomerApiKeysService.ts
@@ -12,9 +12,9 @@ class ListCustomerApiKeysService {
   async call (customerId: string): Promise<CustomerApiKey[]> {
     const command = new ScanCommand({
       TableName: 'CustomerApiKeys',
-      FilterExpression: 'CustomerId = :CustomerId',
+      FilterExpression: 'FpoId = :FpoId',
       ExpressionAttributeValues: {
-        ':CustomerId': customerId
+        ':FpoId': customerId
       }
     })
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Altered the name from customer-id to CustomerId

### Why?

I am doing this because:

- This reduces confusion with API gateway concepts
