### PR TITLE
FPO-143: Source table name from the environment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,4 @@ export AWS_REGION=eu-west-2
 export ENCRYPTION_KEY=bSTK97jzd4gMC89mpRe1mL5Lx1v8I4zhWZmOxHEmzCo=
 export PORT=5001
 export USAGE_PLAN_ID=1ju1kk
+export CUSTOMER_API_KEYS_TABLE_NAME=CustomerApiKeys

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 export AWS_REGION=eu-west-2
 export ENCRYPTION_KEY=Ur2w/rJWwRiLS4LEorod0t8PCgi7mZL9AdfCHwXviRo=
 export USAGE_PLAN_ID=usagePlanId
+export CUSTOMER_API_KEYS_TABLE_NAME=CustomerApiKeys

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ participant Protected Resource / API
 
 Client Application->>Cognito Authorization Server: Request Access Token (Client ID, Client Secret)
 Cognito Authorization Server->>Cognito Authorization Server: Validate Credentials
-Cognito Authorization Server->>Client Application: Access Token 
+Cognito Authorization Server->>Client Application: Access Token
 Client Application->>Protected Resource / API: API Request (Access Token)
 Protected Resource / API->>Protected Resource / API: Validate Token
-Protected Resource / API->>Client Application: API Response 
+Protected Resource / API->>Client Application: API Response
 ```
 
 Access tokens need to be refreshed by the client and the backend decodes/verifies the JWT in the Authorisation header.
 
+## Point in time recovery
+
+When restoring from a PITR snapshot a new table will be generated with the data in it. Change the value of the env var in
+main.tf to update this to the new table name for all environments (e.g. development, staging and production) as this application is released.
 
 ## API Documentation
 
-Once the application is running, open a web browser and navigate to the Swagger UI URL: http://localhost:5001/api-docs
+Once the application is running, open a web browser and navigate to the Swagger UI URL: <http://localhost:5001/api-docs>
 
 This has been disabled to only run in development mode as the endpoints are designed to be be internal.

--- a/src/operations/createCustomerApiKey.ts
+++ b/src/operations/createCustomerApiKey.ts
@@ -5,6 +5,8 @@ import { type APIGatewayClient, CreateApiKeyCommand, type CreateApiKeyCommandInp
 
 import crypto from 'crypto'
 
+const TableName = process.env.CUSTOMER_API_KEYS_TABLE_NAME ?? ''
+
 class CreateCustomerApiKey {
   static CLIENT_ID_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
   static CLIENT_ID_LENGTH = 17
@@ -36,7 +38,7 @@ class CreateCustomerApiKey {
 
   private async createInDynamoDb (customerApiKey: CustomerApiKey): Promise<void> {
     const command = new PutCommand({
-      TableName: 'CustomerApiKeys',
+      TableName,
       Item: customerApiKey.toItem()
     })
 

--- a/src/operations/deleteCustomerApiKey.ts
+++ b/src/operations/deleteCustomerApiKey.ts
@@ -2,6 +2,8 @@ import { type CustomerApiKey } from '../models/customerApiKey'
 import { DeleteItemCommand, type DeleteItemCommandInput, type DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DeleteApiKeyCommand, type DeleteApiKeyCommandInput, type APIGatewayClient } from '@aws-sdk/client-api-gateway'
 
+const TableName = process.env.CUSTOMER_API_KEYS_TABLE_NAME ?? ''
+
 class DeleteCustomerApiKey {
   constructor (
     private readonly dynamodbClient: DynamoDBClient,
@@ -25,7 +27,7 @@ class DeleteCustomerApiKey {
 
   private async deleteInDynamoDb (apiKey: CustomerApiKey): Promise<void> {
     const input: DeleteItemCommandInput = {
-      TableName: 'CustomerApiKeys',
+      TableName,
       Key: {
         FpoId: { S: apiKey.FpoId },
         CustomerApiKeyId: { S: apiKey.CustomerApiKeyId }

--- a/src/operations/listCustomerApiKeys.ts
+++ b/src/operations/listCustomerApiKeys.ts
@@ -2,6 +2,8 @@ import { CustomerApiKey } from '../models/customerApiKey'
 import { type DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { ScanCommand } from '@aws-sdk/lib-dynamodb'
 
+const TableName = process.env.CUSTOMER_API_KEYS_TABLE_NAME ?? ''
+
 class ListCustomerApiKeys {
   private readonly client: DynamoDBClient
 
@@ -11,7 +13,7 @@ class ListCustomerApiKeys {
 
   async call (fpoId: string): Promise<CustomerApiKey[]> {
     const command = new ScanCommand({
-      TableName: 'CustomerApiKeys',
+      TableName,
       FilterExpression: 'FpoId = :FpoId',
       ExpressionAttributeValues: {
         ':FpoId': fpoId

--- a/src/operations/updateCustomerApiKey.ts
+++ b/src/operations/updateCustomerApiKey.ts
@@ -2,6 +2,8 @@ import { type CustomerApiKey } from '../models/customerApiKey'
 import { UpdateItemCommand, type UpdateItemCommandInput, type DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { UpdateApiKeyCommand, type UpdateApiKeyCommandInput, type APIGatewayClient } from '@aws-sdk/client-api-gateway'
 
+const TableName = process.env.CUSTOMER_API_KEYS_TABLE_NAME ?? ''
+
 class UpdateCustomerApiKey {
   constructor (
     private readonly dynamodbClient: DynamoDBClient,
@@ -17,7 +19,7 @@ class UpdateCustomerApiKey {
 
   private async updateDynamoDb (apiKey: CustomerApiKey): Promise<void> {
     const input: UpdateItemCommandInput = {
-      TableName: 'CustomerApiKeys',
+      TableName,
       Key: {
         FpoId: { S: apiKey.FpoId },
         CustomerApiKeyId: { S: apiKey.CustomerApiKeyId }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,6 +49,10 @@ module "service" {
       name  = "SENTRY_ENVIRONMENT"
       value = var.environment
     },
+    {
+      name  = "CUSTOMER_API_KEYS_TABLE_NAME"
+      value = data.aws_dynamodb_table.customer_api_keys.name
+    }
   ]
 
   service_secrets_config = [


### PR DESCRIPTION
### Jira link

FPO-143

### What?

I have added/removed/altered:

- [x] Added environment variable for the dynamodb table

### Why?

I am doing this because:

- When we restore from a Point In Time Recovery (PITR) backup we restore to a new table. We need to make it convenient to change the table name in a single location
