### PR TITLE
Support PATCH /api/keys on Enabled flag

### DIFF
--- a/spec/controllers/apiKeysControllerSpec.ts
+++ b/spec/controllers/apiKeysControllerSpec.ts
@@ -108,43 +108,7 @@ describe('ApiKeyController', () => {
         return this
       }
     } as any
-
-    it('disable the key', async () => {
-      apiKey = new CustomerApiKey()
-      const getKeyResult = Promise.resolve(apiKey)
-      const updateKeyResult = Promise.resolve(apiKey)
-
-      repository = jasmine.createSpyObj(
-        'CustomerApiKeyRepository',
-        {
-          updateKey: updateKeyResult,
-          getKey: getKeyResult
-        }
-      )
-      repository.updateKey.bind(repository)
-      controller = new ApiKeyController(repository)
-      req = { params: { fpoId: 'fpoId', id: 'id' }, body: { enabled: false } } as any
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      await controller.update(req, res)
-
-      expect(repository.getKey).toHaveBeenCalledWith('fpoId', 'id')
-      expect(repository.updateKey).toHaveBeenCalledWith(apiKey)
-      expect(res.statusCode).toBe(200)
-      expect(res.data).toEqual({
-        CustomerApiKeyId: '',
-        ApiGatewayId: '',
-        Secret: '',
-        Enabled: false,
-        Description: '',
-        FpoId: '',
-        CreatedAt: apiKey.CreatedAt,
-        UpdatedAt: apiKey.UpdatedAt,
-        UsagePlanId: ''
-      })
-    })
-
-    it('enable the key', async () => {
+    it('enables the key', async () => {
       apiKey = new CustomerApiKey()
       const getKeyResult = Promise.resolve(apiKey)
       const updateKeyResult = Promise.resolve(apiKey)
@@ -171,6 +135,41 @@ describe('ApiKeyController', () => {
         ApiGatewayId: '',
         Secret: '',
         Enabled: true,
+        Description: '',
+        FpoId: '',
+        CreatedAt: apiKey.CreatedAt,
+        UpdatedAt: apiKey.UpdatedAt,
+        UsagePlanId: ''
+      })
+    })
+
+    it('disables the key', async () => {
+      apiKey = new CustomerApiKey()
+      const getKeyResult = Promise.resolve(apiKey)
+      const updateKeyResult = Promise.resolve(apiKey)
+
+      repository = jasmine.createSpyObj(
+        'CustomerApiKeyRepository',
+        {
+          updateKey: updateKeyResult,
+          getKey: getKeyResult
+        }
+      )
+      repository.updateKey.bind(repository)
+      controller = new ApiKeyController(repository)
+      req = { params: { fpoId: 'fpoId', id: 'id' }, body: { enabled: false } } as any
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      await controller.update(req, res)
+
+      expect(repository.getKey).toHaveBeenCalledWith('fpoId', 'id')
+      expect(repository.updateKey).toHaveBeenCalledWith(apiKey)
+      expect(res.statusCode).toBe(200)
+      expect(res.data).toEqual({
+        CustomerApiKeyId: '',
+        ApiGatewayId: '',
+        Secret: '',
+        Enabled: false,
         Description: '',
         FpoId: '',
         CreatedAt: apiKey.CreatedAt,

--- a/spec/controllers/apiKeysControllerSpec.ts
+++ b/spec/controllers/apiKeysControllerSpec.ts
@@ -109,7 +109,7 @@ describe('ApiKeyController', () => {
       }
     } as any
 
-    it('updates the key', async () => {
+    it('disable the key', async () => {
       apiKey = new CustomerApiKey()
       const getKeyResult = Promise.resolve(apiKey)
       const updateKeyResult = Promise.resolve(apiKey)
@@ -123,7 +123,7 @@ describe('ApiKeyController', () => {
       )
       repository.updateKey.bind(repository)
       controller = new ApiKeyController(repository)
-      req = { params: { fpoId: 'fpoId', id: 'id' }, body: { description: 'description' } } as any
+      req = { params: { fpoId: 'fpoId', id: 'id' }, body: { enabled: false } } as any
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await controller.update(req, res)
@@ -136,7 +136,42 @@ describe('ApiKeyController', () => {
         ApiGatewayId: '',
         Secret: '',
         Enabled: false,
-        Description: 'description',
+        Description: '',
+        FpoId: '',
+        CreatedAt: apiKey.CreatedAt,
+        UpdatedAt: apiKey.UpdatedAt,
+        UsagePlanId: ''
+      })
+    })
+
+    it('enable the key', async () => {
+      apiKey = new CustomerApiKey()
+      const getKeyResult = Promise.resolve(apiKey)
+      const updateKeyResult = Promise.resolve(apiKey)
+
+      repository = jasmine.createSpyObj(
+        'CustomerApiKeyRepository',
+        {
+          updateKey: updateKeyResult,
+          getKey: getKeyResult
+        }
+      )
+      repository.updateKey.bind(repository)
+      controller = new ApiKeyController(repository)
+      req = { params: { fpoId: 'fpoId', id: 'id' }, body: { enabled: true } } as any
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      await controller.update(req, res)
+
+      expect(repository.getKey).toHaveBeenCalledWith('fpoId', 'id')
+      expect(repository.updateKey).toHaveBeenCalledWith(apiKey)
+      expect(res.statusCode).toBe(200)
+      expect(res.data).toEqual({
+        CustomerApiKeyId: '',
+        ApiGatewayId: '',
+        Secret: '',
+        Enabled: true,
+        Description: '',
         FpoId: '',
         CreatedAt: apiKey.CreatedAt,
         UpdatedAt: apiKey.UpdatedAt,

--- a/spec/operations/updateCustomerApiKeySpec.ts
+++ b/spec/operations/updateCustomerApiKeySpec.ts
@@ -16,7 +16,7 @@ describe('UpdateCustomerApiKey', () => {
     createCustomerApiKey = new UpdateCustomerApiKey(dynamodbClient, apigatewayClient)
   })
 
-  it('disable the api key', async () => {
+  it('disables the api key', async () => {
     const key = new CustomerApiKey()
     key.FpoId = 'fpoId'
     key.Enabled = false
@@ -54,7 +54,7 @@ describe('UpdateCustomerApiKey', () => {
     }))
   })
 
-  it('enable the api key', async () => {
+  it('enables the api key', async () => {
     const key = new CustomerApiKey()
     key.FpoId = 'fpoId'
     key.Enabled = true

--- a/spec/operations/updateCustomerApiKeySpec.ts
+++ b/spec/operations/updateCustomerApiKeySpec.ts
@@ -16,17 +16,17 @@ describe('UpdateCustomerApiKey', () => {
     createCustomerApiKey = new UpdateCustomerApiKey(dynamodbClient, apigatewayClient)
   })
 
-  it('updates the api key', async () => {
+  it('disable the api key', async () => {
     const key = new CustomerApiKey()
     key.FpoId = 'fpoId'
-    key.Description = 'new description'
+    key.Enabled = false
     key.ApiGatewayId = 'apiGatewayId'
     key.CustomerApiKeyId = 'customerId'
 
     const updated = await createCustomerApiKey.call(key)
 
     expect(updated.FpoId).toEqual('fpoId')
-    expect(updated.Description).toEqual('new description')
+    expect(updated.Enabled).toEqual(false)
     expect(dynamodbClient.send).toHaveBeenCalledTimes(1)
     expect(apigatewayClient.send).toHaveBeenCalledTimes(1)
 
@@ -35,8 +35,8 @@ describe('UpdateCustomerApiKey', () => {
       patchOperations: [
         {
           op: 'replace',
-          path: '/description',
-          value: 'new description'
+          path: '/enabled',
+          value: String(false)
         }
       ]
     }))
@@ -47,9 +47,47 @@ describe('UpdateCustomerApiKey', () => {
         FpoId: { S: 'fpoId' },
         CustomerApiKeyId: { S: 'customerId' }
       },
-      UpdateExpression: 'SET Description = :description',
+      UpdateExpression: 'SET Enabled = :enabled',
       ExpressionAttributeValues: {
-        ':description': { S: 'new description' }
+        ':enabled': { BOOL: false }
+      }
+    }))
+  })
+
+  it('enable the api key', async () => {
+    const key = new CustomerApiKey()
+    key.FpoId = 'fpoId'
+    key.Enabled = true
+    key.ApiGatewayId = 'apiGatewayId'
+    key.CustomerApiKeyId = 'customerId'
+
+    const updated = await createCustomerApiKey.call(key)
+
+    expect(updated.FpoId).toEqual('fpoId')
+    expect(updated.Enabled).toEqual(true)
+    expect(dynamodbClient.send).toHaveBeenCalledTimes(1)
+    expect(apigatewayClient.send).toHaveBeenCalledTimes(1)
+
+    expect(apigatewayClient.send.calls.first().args[0].input).toEqual(jasmine.objectContaining({
+      apiKey: 'apiGatewayId',
+      patchOperations: [
+        {
+          op: 'replace',
+          path: '/enabled',
+          value: String(true)
+        }
+      ]
+    }))
+
+    expect(dynamodbClient.send.calls.first().args[0].input).toEqual(jasmine.objectContaining({
+      TableName: 'CustomerApiKeys',
+      Key: {
+        FpoId: { S: 'fpoId' },
+        CustomerApiKeyId: { S: 'customerId' }
+      },
+      UpdateExpression: 'SET Enabled = :enabled',
+      ExpressionAttributeValues: {
+        ':enabled': { BOOL: true }
       }
     }))
   })

--- a/src/controllers/apiKeysController.ts
+++ b/src/controllers/apiKeysController.ts
@@ -48,9 +48,8 @@ export class ApiKeyController {
       res.status(404).json({ message: 'API key not found' })
       return
     }
-
-    if (body.description !== undefined && typeof body.description === 'string') {
-      customerApiKey.Description = body.description
+    if (body.enabled !== undefined && typeof body.enabled === 'boolean') {
+      customerApiKey.Enabled = body.enabled
     } else {
       res.status(400).json({ message: 'Invalid request' })
       return

--- a/src/docs/apiDocs.ts
+++ b/src/docs/apiDocs.ts
@@ -106,9 +106,9 @@ const apiDocs = {
             schema: {
               type: 'object',
               properties: {
-                description: {
-                  type: 'string',
-                  description: 'New description of the API key'
+                enabled: {
+                  type: 'boolean',
+                  description: 'New value'
                 }
               }
             }

--- a/src/operations/updateCustomerApiKey.ts
+++ b/src/operations/updateCustomerApiKey.ts
@@ -24,10 +24,10 @@ class UpdateCustomerApiKey {
         FpoId: { S: apiKey.FpoId },
         CustomerApiKeyId: { S: apiKey.CustomerApiKeyId }
       },
-      UpdateExpression: 'SET Description = :description',
+      UpdateExpression: 'SET Enabled = :enabled',
       // Only description is allowed to be updated
       ExpressionAttributeValues: {
-        ':description': { S: apiKey.Description }
+        ':enabled': { BOOL: apiKey.Enabled }
       }
     }
 
@@ -42,8 +42,8 @@ class UpdateCustomerApiKey {
       patchOperations: [
         {
           op: 'replace',
-          path: '/description',
-          value: apiKey.Description
+          path: '/enabled',
+          value: String(apiKey.Enabled)
         }
       ]
     }


### PR DESCRIPTION
### Jira link
[FPO-190](https://transformuk.atlassian.net/browse/FPO-190)
### What?

I have added/removed/altered:

- [x] Altered the update endpoint to enable/disable a api key

### Why?

I am doing this because:

- because it does not exist at the moment

### AC

- Tested locally
