### PR TITLE
FPO-205: Adds implicit update audit timestamp

### DIFF
--- a/spec/operations/updateCustomerApiKeySpec.ts
+++ b/spec/operations/updateCustomerApiKeySpec.ts
@@ -47,9 +47,10 @@ describe('UpdateCustomerApiKey', () => {
         FpoId: { S: 'fpoId' },
         CustomerApiKeyId: { S: 'customerId' }
       },
-      UpdateExpression: 'SET Enabled = :enabled',
+      UpdateExpression: 'SET Enabled = :enabled, UpdatedAt = :updatedAt',
       ExpressionAttributeValues: {
-        ':enabled': { BOOL: false }
+        ':enabled': { BOOL: false },
+        ':updatedAt': { S: jasmine.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/) }
       }
     }))
   })
@@ -85,9 +86,10 @@ describe('UpdateCustomerApiKey', () => {
         FpoId: { S: 'fpoId' },
         CustomerApiKeyId: { S: 'customerId' }
       },
-      UpdateExpression: 'SET Enabled = :enabled',
+      UpdateExpression: 'SET Enabled = :enabled, UpdatedAt = :updatedAt',
       ExpressionAttributeValues: {
-        ':enabled': { BOOL: true }
+        ':enabled': { BOOL: true },
+        ':updatedAt': { S: jasmine.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/) }
       }
     }))
   })

--- a/src/operations/updateCustomerApiKey.ts
+++ b/src/operations/updateCustomerApiKey.ts
@@ -24,10 +24,10 @@ class UpdateCustomerApiKey {
         FpoId: { S: apiKey.FpoId },
         CustomerApiKeyId: { S: apiKey.CustomerApiKeyId }
       },
-      UpdateExpression: 'SET Enabled = :enabled',
-      // Only description is allowed to be updated
+      UpdateExpression: 'SET Enabled = :enabled, UpdatedAt = :updatedAt',
       ExpressionAttributeValues: {
-        ':enabled': { BOOL: apiKey.Enabled }
+        ':enabled': { BOOL: apiKey.Enabled },
+        ':updatedAt': { S: new Date().toISOString() }
       }
     }
 


### PR DESCRIPTION
### Jira link

FPO-205

### What?

I have added/removed/altered:

- [x] Added implicit timestamp to dynamodb items

### Why?

I am doing this because:

- This is to properly audit these and highlight when they were enabled/disabled